### PR TITLE
Update thread gather check.

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,7 +231,7 @@ if ( cluster.isMaster ) {
                             case 1:
                                 finishedWorkers++;
                                 if ( argv.verbose ) { console.log( 'Thread ' + ( worker[ 'id' ]-1 ) + ' is done rendering.' ); };
-                                if ( finishedWorkers === os.cpus().length ) {
+                                if ( finishedWorkers === argv.threads ) {
                                     if ( argv.verbose ) { console.log( 'All threads are done rendering.' ); };
                                     processLeafletMap();
                                 };


### PR DESCRIPTION
Fixes issue https://github.com/clarkx86/papyrusjs/issues/4. Checks to see if the exited thread count is the same as the number of threads spawned and not the number of reported CPUs. Otherwise the master stalls waiting for non-existent threads to exit.