### PR TITLE
Add more override texture mappings

### DIFF
--- a/src/lookup_tables/patch-textures_table.json
+++ b/src/lookup_tables/patch-textures_table.json
@@ -332,6 +332,86 @@
             "textures/blocks/stripped_dark_oak_log",
             null,
             null ] },
+    "stone_slab": {
+        "textures": [
+            "textures/blocks/stone_slab_top",
+            "textures/blocks/sandstone_top",
+            "textures/blocks/planks_oak",
+            "textures/blocks/cobblestone",
+            "textures/blocks/brick",
+            "textures/blocks/stonebrick",
+            "textures/blocks/quartz_block_top",
+            "textures/blocks/nether_brick",
+            "textures/blocks/stone_slab_top",
+            "textures/blocks/sandstone_top",
+            "textures/blocks/planks_oak",
+            "textures/blocks/cobblestone",
+            "textures/blocks/brick",
+            "textures/blocks/stonebrick",
+            "textures/blocks/quartz_block_top",
+            "textures/blocks/nether_brick"
+        ]
+    },
+    "stone_slab2": {
+        "textures": [
+            "textures/blocks/red_sandstone_top",
+            "textures/blocks/purpur_block",
+            "textures/blocks/prismarine_rough",
+            "textures/blocks/prismarine_bricks",
+            "textures/blocks/prismarine_dark",
+            "textures/blocks/cobblestone_mossy",
+            "textures/blocks/sandstone_smooth",
+            "textures/blocks/red_nether_brick",
+            "textures/blocks/red_sandstone_top",
+            "textures/blocks/purpur_block",
+            "textures/blocks/prismarine_rough",
+            "textures/blocks/prismarine_bricks",
+            "textures/blocks/prismarine_dark",
+            "textures/blocks/cobblestone_mossy",
+            "textures/blocks/sandstone_smooth",
+            "textures/blocks/red_nether_brick"
+        ]
+    },
+    "stone_slab3": {
+        "textures": [
+            "textures/blocks/end_bricks",
+            "textures/blocks/red_sandstone_smooth",
+            "textures/blocks/stone_andesite_smooth",
+            "textures/blocks/stone_andesite",
+            "textures/blocks/stone_diorite",
+            "textures/blocks/stone_diorite_smooth",
+            "textures/blocks/stone_granite",
+            "textures/blocks/stone_granite_smooth",
+            "textures/blocks/end_bricks",
+            "textures/blocks/red_sandstone_smooth",
+            "textures/blocks/stone_andesite_smooth",
+            "textures/blocks/stone_andesite",
+            "textures/blocks/stone_diorite",
+            "textures/blocks/stone_diorite_smooth",
+            "textures/blocks/stone_granite",
+            "textures/blocks/stone_granite_smooth"
+        ]
+    },
+    "stone_slab4": {
+        "textures": [
+            "textures/blocks/stonebrick_mossy",
+            "textures/blocks/quartz_block_top",
+            "textures/blocks/stone",
+            "textures/blocks/sandstone_carved",
+            "textures/blocks/red_sandstone_carved",
+            null,
+            null,
+            null,
+            "textures/blocks/stonebrick_mossy",
+            "textures/blocks/quartz_block_top",
+            "textures/blocks/stone",
+            "textures/blocks/sandstone_carved",
+            "textures/blocks/red_sandstone_carved",
+            null,
+            null,
+            null
+        ]
+    },
     "door_lower": {
         "textures": [
             null,

--- a/src/lookup_tables/patch-textures_table.json
+++ b/src/lookup_tables/patch-textures_table.json
@@ -224,6 +224,26 @@
         "textures/blocks/pumpkin_stem_connected"
       ]
     },
+    "melon_top": {
+      "textures": [
+        "textures/blocks/melon_top",
+        "textures/blocks/melon_top",
+        "textures/blocks/melon_top",
+        "textures/blocks/melon_top"
+      ]
+    },
+    "melon_stem": {
+      "textures": [
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_disconnected",
+        "textures/blocks/melon_stem_connected"
+      ]
+    },
     "chest_inventory_top": {
         "textures": [
             null,

--- a/src/lookup_tables/patch-textures_table.json
+++ b/src/lookup_tables/patch-textures_table.json
@@ -332,7 +332,7 @@
             "textures/blocks/stripped_dark_oak_log",
             null,
             null ] },
-    "stone_slab": {
+    "stone_slab_top": {
         "textures": [
             "textures/blocks/stone_slab_top",
             "textures/blocks/sandstone_top",
@@ -352,7 +352,7 @@
             "textures/blocks/nether_brick"
         ]
     },
-    "stone_slab2": {
+    "stone_slab_top_2": {
         "textures": [
             "textures/blocks/red_sandstone_top",
             "textures/blocks/purpur_block",
@@ -372,7 +372,7 @@
             "textures/blocks/red_nether_brick"
         ]
     },
-    "stone_slab3": {
+    "stone_slab_top_3": {
         "textures": [
             "textures/blocks/end_bricks",
             "textures/blocks/red_sandstone_smooth",
@@ -392,7 +392,7 @@
             "textures/blocks/stone_granite_smooth"
         ]
     },
-    "stone_slab4": {
+    "stone_slab_top_4": {
         "textures": [
             "textures/blocks/stonebrick_mossy",
             "textures/blocks/quartz_block_top",


### PR DESCRIPTION
Adds mappings for melon stems and tops as well as for all varieties of stone slabs. This should resolve issue https://github.com/clarkx86/papyrusjs/issues/11.